### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/floorplanarea-2.py
+++ b/floorplanarea-2.py
@@ -27,7 +27,7 @@ class RoomAreaView(ui.View):
 	''' top level container, consisting of an imageview and an overlay	.  
 	ideally this might also contain a menu bar, for changing the mode - for instance you might have a button for enabling room drawing, another one for editing points, another for zoom/pan'''
 	def scrollview_should_scroll(self,sv):
-		return false
+		return False
 	def __init__(self,file):
 		#create image view that fills this top level view.
 		#  since this RoomAreaView is the one that gets presented, it will be resized automatically, so we want the imageview to stay tied to the full view size, so we use flex.  Also, the content mode is important to prevent the image from being squished
@@ -71,7 +71,7 @@ class RoomAreaView(ui.View):
 		'''upon close, dump out the current area.  do this by first getting the set of points.  The zip notation lets us convert from a tuple of the form ((x0,y0),(x1,y1),...) to x=(x0,x1,...) and y=(y0,y1,...)'''
 		if self.pts:
 			x,y=zip(*self.rv.pts)
-			print (polygonArea(x,y,float(self.rv.scale.text)))
+			print(polygonArea(x,y,float(self.rv.scale.text)))
 class RoomAreaOverlay(ui.View):
 	'''A touch sensitive overlay.  Touches add to a list of points, which are then used to compute area.  Lengths are shown for each line segment, snd a scaling parameter is used to adjust the length of drawn lines to known dimensions'''
 	def __init__(self,*args,**kwargs):

--- a/floorplanarea-4.py
+++ b/floorplanarea-4.py
@@ -1,5 +1,6 @@
 #!python2
 # coding: utf-8
+from __future__ import print_function
 import ui, photos
 class RoomAreaView(ui.View):
 	''' top level container, consisting of an imageview and an overlay.  
@@ -21,7 +22,7 @@ class RoomAreaView(ui.View):
 	def will_close(self):
 		'''upon close, dump out the current area.  do this by first getting the set of points.  The zip notation lets us convert from a tuple of the form ((x0,y0),(x1,y1),...) to x=(x0,x1,...) and y=(y0,y1,...)'''
 		x,y=zip(*self.rv.pts)
-		print polygonArea(x,y,float(self.rv.scale.value)), self.rv.scale.value
+		print(polygonArea(x,y,float(self.rv.scale.value)), self.rv.scale.value)
 class RoomAreaOverlay(ui.View):
 	'''A touch sensitive overlay.  Touches add to a list of points, which are then used to compute area.  Lengths are shown for each line segment, and a scaling parameter is used to adjust the length of drawn lines to known dimensions'''
 	def __init__(self,*args,**kwargs):

--- a/floorplanarea-6.py
+++ b/floorplanarea-6.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 #!python2
 # coding: utf-8
+from __future__ import print_function
 import ui
 import photos
 
@@ -33,7 +34,7 @@ class RoomAreaView(ui.View):
     def will_close(self):
         '''upon close, dump out the current area.  do this by first getting the set of points.  The zip notation lets us convert from a tuple of the form ((x0,y0),(x1,y1),...) to x=(x0,x1,...) and y=(y0,y1,...)'''
         x, y = zip(*self.rv.pts)
-        print polygonArea(x, y, float(self.rv.scale.value)), self.rv.scale.value / 10
+        print(polygonArea(x, y, float(self.rv.scale.value)), self.rv.scale.value / 10)
 
 
 class RoomAreaOverlay(ui.View):

--- a/floorplanarea.py
+++ b/floorplanarea.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import print_function
 import ui
 class RoomAreaView(ui.View):
 	def __init__(self,file):
@@ -13,7 +14,7 @@ class RoomAreaView(ui.View):
 		self.rv=rv
 	def will_close(self):
 		x,y=zip(*self.rv.pts)
-		print polygonArea(x,y,float(self.rv.scale.text))
+		print(polygonArea(x,y,float(self.rv.scale.text)))
 class RoomAreaOverlay(ui.View):
 	def __init__(self,*args,**kwargs):
 		ui.View.__init__(self,*args,**kwargs)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.